### PR TITLE
Fixes issue #3 muffin build.

### DIFF
--- a/x11-wm/muffin/muffin-4.4.3-r2.ebuild
+++ b/x11-wm/muffin/muffin-4.4.3-r2.ebuild
@@ -82,6 +82,7 @@ src_configure() {
 		--enable-xsync \
 		--enable-verbose-mode \
 		--with-libcanberra \
+		--enable-wayland-egl-server=no \
 		$(use_enable introspection) \
 		$(use_enable xinerama)
 }


### PR DESCRIPTION
Bump muffin ebuild version to r2 and explicitly disable wayland-egl-server during build configuration.